### PR TITLE
yotpo: Correct required input for post redemptions

### DIFF
--- a/specs/yotpo/loyalty.yml
+++ b/specs/yotpo/loyalty.yml
@@ -781,10 +781,6 @@ paths:
             schema:
               type: object
               required:
-                - customer_email
-                - pos_account_id
-                - phone_number
-                - customer_id
                 - redemption_option_id
               properties:
                 customer_email:


### PR DESCRIPTION
In the openapi spec these inputs are considered required but in reality it's a "required only required if another thing is not provided" scenario which is not truly "required"

https://loyaltyapi.yotpo.com/reference/create-redemption